### PR TITLE
adds a call to tmpdir() for saving soy cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var through = require("through"),
     Buffer = require("buffer").Buffer,
     PluginError = gutil.PluginError,
     fs = require("fs"),
+    os = require("os"),
     File = gutil.File,
     closureTemplates = require("closure-templates"),
     path = require("path"),
@@ -14,7 +15,7 @@ module.exports = function (options) {
         options = {};
     }
 
-    var tmp = path.resolve(options.tmpDir || "/tmp/soy"),
+    var tmp = path.resolve(options.tmpDir || path.join(os.tmpdir(), "soy")),
         addSoyUtils = options.hasOwnProperty("soyutils") ? options.soyutils : true,
         compilerFlags = options.hasOwnProperty("compilerFlags") ? options.compilerFlags : [],
         useClosure = options.hasOwnProperty("useClosure") ? options.useClosure : false,


### PR DESCRIPTION
I think this method should be a bit safer across configurations.  Instead of hitting the hardcoded /tmp/soy directory, this method will create a soy cache directory in your systems default tmp directory.  In my case, the directory lived in /var.
