### PR TITLE
Update md5 to v2.0.0 to prevent deprecation warnings.  Also prevents …

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var through = require("through"),
     closureTemplates = require("closure-templates"),
     path = require("path"),
     spawn = require("child_process").spawn,
-    md5 = require("MD5");
+    md5 = require("md5");
 
 module.exports = function (options) {
     if (typeof options !== "object") {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "through": "^2.3.4",
         "gulp-util": "^2.2.5",
         "closure-templates": "20130416.0.0",
-        "MD5": "^1.2.1"
+        "MD5": "^2.0.0"
     },
     "devDependencies": {
         "mocha": "*",


### PR DESCRIPTION
…compatibility issue with phantomjs.
